### PR TITLE
V2.0.0 W3ID.org redirects

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,6 +14,7 @@
   * [Authentication strategy](technical-specifications/authentication-strategy.md)
   * [Architecture representations](technical-specifications/architecture-representations.md)
   * [Order states](technical-specifications/order-states.md)
+  * [URI Redirection](technical-specifications/uri-redirection.md)
 * [Prototype specifications](prototype-specifications.md)
 * [🚧 Solid client protocol](solid-client-protocol.md)
 * [🚧 Connector](connector/README.md)

--- a/technical-specifications/README.md
+++ b/technical-specifications/README.md
@@ -12,6 +12,7 @@ We divided this chapter into 4 parts:
 * [Decentralized identifier matching reference system](decentralised-identifier-matching-reference-system.md) where we will explain why we are not building a centralized referential but rather promoting platforms intermediation.
 * [Authentication strategy](authentication-strategy.md) where we will discuss the use of OpenID protocol as our authentication layer.
 * [Architecture representations](architecture-representations.md) where we will finally resume all these information into a nice schema.
+* [URI Redirection](uri-redirection.md) where we document how DFC ontology & taxonomy files are served via the w3id.org permanent redirection service.
 
 ## Decisions and choices history
 

--- a/technical-specifications/uri-redirection.md
+++ b/technical-specifications/uri-redirection.md
@@ -1,0 +1,55 @@
+# URI Redirection
+
+We have introduced URI redirection to futureproof changes to how we store/serve DFC ontology & taxonomy files.
+
+We are utilising the [w3id.org](https://w3id.org) permanent redirection service.
+
+All DFC URI's can be accessed via the <https://w3id.org/dfc> route.
+
+## Ontology URI's
+
+To access the Ontology releases, use the following URI pattern(s):
+
+### Business Ontology Files
+
+All Ontology files are stored in the `/src/` folder of the [ontology repo](https://github.com/datafoodconsortium/ontology).
+
+The latest version can be accessed via the URI: <https://w3id.org/dfc/ontology/src/DFC_BusinessOntology.owl>
+
+We strongly recommend all applications use URI's for the specific version they are accessing. Those follow the pattern:
+
+<https://w3id.org/dfc/ontology/{full-version-number, including v}/src/DFC_BusinessOntology.owl>
+
+For example to access the v1.16.0 Ontology file, you would use: <https://w3id.org/dfc/ontology/v1.16.0/src/DFC_BusinessOntology.owl>
+
+### Context Files
+
+Context files are stored in the `/contexts/` folder of the ontology repo.
+
+All context files include the version number in the filename, so MUST be accessed explicitly.
+
+To access a context file, use the following URI pattern:
+
+<https://w3id.org/dfc/ontology/contexts/context.{full-version-number, including v}.json>
+
+It is recommended not to include the release version earlier in the URI pattern; this will access the specific context file in the latest ontology release.
+
+## Taxonomy Files
+
+All taxonomy files can be accessed via the following URI patterns:
+
+### Latest version
+
+To access the current version use the pattern:
+
+<https://w3id.org/dfc/taxonomies/{required taxonomy file, including rdf/json suffix}>
+
+### Specific version
+
+To access a specific version use the pattern:
+
+<https://w3id.org/dfc/taxonomies/{full-version-number, including v}/{required taxonomy file, including rdf/json suffix}>
+
+So to access the v2.0.0 facets file in RDF format, you would specify:
+
+<https://w3id.org/dfc/taxonomies/v2.0.0/facets.rdf>


### PR DESCRIPTION
Transfers GitBook change #152 ("V2.0.0 W3ID.org redirects") to a GitHub PR.

Adds a new **URI Redirection** page under Technical Specifications documenting the `w3id.org/dfc` permanent redirection service used to serve DFC ontology & taxonomy files (latest and versioned URI patterns for ontology, context and taxonomy files).

Changes:
- `technical-specifications/uri-redirection.md` (new)
- `SUMMARY.md` — add the new page to the table of contents
- `technical-specifications/README.md` — add a link to the new page